### PR TITLE
fix: upper pin for numpy to satisfy pyshed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "matplotlib",
     "matplotlib-scalebar",
     "netCDF4",
-    "numpy>=2.0",
+    "numpy>=2.0,<2.5",
     "pandas<3.0",
     "plotly",
     "pyproj",


### PR DESCRIPTION
# Fix: upper pin numpy in v1.0
## Issue
```
git clone git@github.com:HydroModPy/HydroModPy.git && cd HydroModPy && git checkout v1.0 && uv sync
```
Fails with
```
  × Failed to build `llvmlite==0.36.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stderr]
      /home/lesimppa/.cache/uv/builds-v0/.tmpC0chle/lib/python3.12/site-packages/setuptools/_vendor/wheel/bdist_wheel.py:4:
      FutureWarning: The 'wheel' package is no longer the canonical location of the
      'bdist_wheel' command, and will be removed in a future release. Please update to
      setuptools v70.1 or later which contains an integrated version of this command.
        warn(
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File
      "/home/lesimppa/.cache/uv/builds-v0/.tmpC0chle/lib/python3.12/site-packages/setuptools/build_meta.py",
      line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/home/lesimppa/.cache/uv/builds-v0/.tmpC0chle/lib/python3.12/site-packages/setuptools/build_meta.py",
      line 301, in _get_build_requires
          self.run_setup()
        File
      "/home/lesimppa/.cache/uv/builds-v0/.tmpC0chle/lib/python3.12/site-packages/setuptools/build_meta.py",
      line 520, in run_setup
          super().run_setup(setup_script=setup_script)
        File
      "/home/lesimppa/.cache/uv/builds-v0/.tmpC0chle/lib/python3.12/site-packages/setuptools/build_meta.py",
      line 317, in run_setup
          exec(code, locals())
        File "<string>", line 55, in <module>
        File "<string>", line 52, in _guard_py_ver
      RuntimeError: Cannot install on Python version 3.12.13; only versions >=3.6,<3.10
      are supported.
```
## Fix
Pin numpy to `<2.5` to avoid issues.